### PR TITLE
Add Super EGA (800x600) mode support

### DIFF
--- a/VDDINT.ASM
+++ b/VDDINT.ASM
@@ -32,6 +32,7 @@
 ; EXTRN routines and data
 ;
 VxD_CODE_SEG
+	EXTRN	VDD_Set_SuperEGA_Mode:NEAR
 	EXTRN	VDD_IO_SetTrap:NEAR
 	EXTRN	VDD_Detach2:NEAR
 	EXTRN	VDD_Mem_I10Done:NEAR
@@ -151,6 +152,8 @@ VI10ExitEmYes:
 	ret
 
 VI10NotTTY:
+	cmp	ax, 6Fh			    ; Q: Set Super EGA mode?
+	je	VI10_Set_Super_EGA	    ;	Y: Go do it
 	cmp	ah,2			    ; Q: Set cursor posn?
 	je	VI10SetCurs		    ;	Y: Go do it
 	or	ah,ah			    ; Q: Mode setting?

--- a/VDDMEM.ASM
+++ b/VDDMEM.ASM
@@ -139,6 +139,7 @@ IFDEF	VGA
 	DD	0000000FFh		; mode 11, 640x480 graphics, 1 38k pln
 	DD	0FFFFFFFFh		; mode 12, 640x480 graphics, 4 38k plns
 	DD	0000000FFh		; mode 13, 320x200x8 graphics, 1 64k pln
+	DD	0FFFFFFFFh		; mode 14h, 800x600 graphics
 ENDIF
 
     ;
@@ -170,6 +171,7 @@ IFDEF	VGA
 	DD	000000003h		; mode 11, 640x480 graphics, 1 38k pln
 	DD	003030303h		; mode 12, 640x480 graphics, 4 38k plns
 	DD	0000000FFh		; mode 13, 320x200x8 graphics, 1 64k pln
+	DD	003030303h		; mode 14h, 800x600 graphics
 ENDIF
 
     ;
@@ -200,6 +202,7 @@ IFDEF	VGA
 	DD	0000000FFh		; mode 11, 640x480 graphics, 1 38k pln
 	DD	0FFFFFFFFh		; mode 12, 640x480 graphics, 4 38k plns
 	DD	0000000FFh		; mode 13, 320x200x8 graphics, 1 64k pln
+	DD	0FFFFFFFFh		; mode 14h, 800x600 graphics
 ENDIF
 
     ;
@@ -230,6 +233,7 @@ IFDEF	VGA
 	DD	0000000FFh		; mode 11, 640x480 graphics, 1 38k pln
 	DD	0FFFFFFFFh		; mode 12, 640x480 graphics, 4 38k plns
 	DD	0000000FFh		; mode 13, 320x200x8 graphics, 1 64k pln
+	DD	0FFFFFFFFh		; mode 14h, 800x600 graphics
 ENDIF
 
 VxD_DATA_ENDS

--- a/VDDVGA.ASM
+++ b/VDDVGA.ASM
@@ -27,6 +27,7 @@
 
 IFDEF	VGA
 	INCLUDE vga.inc
+	INCLUDE superega.inc
 
 ;******************************************************************************
 ; EXTRN routines
@@ -34,6 +35,7 @@ IFDEF	VGA
 VxD_CODE_SEG
 	EXTRN	VDD_Get_Mode:NEAR
 	EXTRN	VDD_Mem_Chg:NEAR
+	EXTRN	VDD_Mem_AMain:NEAR
 VxD_CODE_ENDS
 
 ;******************************************************************************
@@ -1538,6 +1540,102 @@ BeginProc ATi_ExtRegs_PreSR, PUBLIC
 ATiER_PS_Exit:
         ret
 EndProc ATi_ExtRegs_PreSR
+
+BeginProc VDD_Set_SuperEGA_Mode, PUBLIC
+    ; Set the memory allocation for the new mode
+    mov al, 14h
+    call VDD_Mem_AMain
+    SetFlag [edi.VDD_Flags], fVDD_256
+
+    ; Disable screen output
+    mov dx, pStatColr
+    in al, dx
+    mov dx, pAttrEGA
+    mov al, 0
+    out dx, al
+
+    ; Write Misc Output Register
+    mov dx, pMiscEGA
+    mov al, SuperEGA_ModeData_Misc
+    out dx, al
+
+    ; Write Sequencer Registers
+    mov cx, 5
+    lea si, SuperEGA_ModeData_SEQ
+    mov dx, pSeqIndx
+    xor ah, ah
+Set_SEQ_Loop:
+    mov al, ah
+    out dx, al
+    inc dx
+    lodsb
+    out dx, al
+    dec dx
+    inc ah
+    loop Set_SEQ_Loop
+
+    ; Unlock CRTC Registers
+    mov dx, pIndx6845Colr
+    mov al, 11h
+    out dx, al
+    inc dx
+    in al, dx
+    and al, 7Fh
+    out dx, al
+    dec dx
+
+    ; Write CRTC Registers
+    mov cx, 18
+    lea si, SuperEGA_ModeData_CRTC
+    mov dx, pIndx6845Colr
+    xor ah, ah
+Set_CRTC_Loop:
+    mov al, ah
+    out dx, al
+    inc dx
+    lodsb
+    out dx, al
+    dec dx
+    inc ah
+    loop Set_CRTC_Loop
+
+    ; Write Graphics Controller Registers
+    mov cx, 9
+    lea si, SuperEGA_ModeData_GC
+    mov dx, pGrpIndx
+    xor ah, ah
+Set_GC_Loop:
+    mov al, ah
+    out dx, al
+    inc dx
+    lodsb
+    out dx, al
+    dec dx
+    inc ah
+    loop Set_GC_Loop
+
+    ; Write Attribute Controller Registers
+    mov cx, 21
+    lea si, SuperEGA_ModeData_AC
+    mov dx, pAttrEGA
+    xor ah, ah
+Set_AC_Loop:
+    mov al, ah
+    out dx, al
+    lodsb
+    out dx, al
+    inc ah
+    loop Set_AC_Loop
+
+    ; Enable screen output
+    mov dx, pStatColr
+    in al, dx
+    mov dx, pAttrEGA
+    mov al, 20h
+    out dx, al
+
+    ret
+EndProc VDD_Set_SuperEGA_Mode
 
 ;******************************************************************************
 ;

--- a/superega.inc
+++ b/superega.inc
@@ -1,0 +1,20 @@
+;******************************************************************************
+;
+; superega.inc - Register values for 800x600x16 Super EGA mode
+;
+;******************************************************************************
+
+; Miscellaneous Output Register (3C2h)
+SuperEGA_ModeData_Misc DB 0E7h
+
+; Sequencer Registers (3C4h/3C5h)
+SuperEGA_ModeData_SEQ DB 03h, 01h, 0Fh, 00h, 06h
+
+; CRTC Registers (3D4h/3D5h)
+SuperEGA_ModeData_CRTC DB 7Fh, 63h, 64h, 82h, 68h, 98h, 0Bh, 3Eh, 00h, 40h, EAh, 8Ch, DFh, 64h, 00h, E7h, 04h, E3h
+
+; Graphics Controller Registers (3CEh/3CFh)
+SuperEGA_ModeData_GC DB 00h, 00h, 00h, 00h, 00h, 40h, 05h, 0Fh, FFh
+
+; Attribute Controller Registers (3C0h/3C1h)
+SuperEGA_ModeData_AC DB 00h, 01h, 02h, 03h, 04h, 05h, 14h, 07h, 38h, 39h, 3Ah, 3Bh, 3Ch, 3Dh, 3Eh, 3Fh, 41h, 00h, 0Fh, 00h, 00h


### PR DESCRIPTION
This change adds support for a new Super EGA video mode with a resolution of 800x600 and 16 colors.

The changes include:
- A new include file, `superega.inc`, with the register values for the new mode.
- A new function, `VDD_Set_SuperEGA_Mode`, in `VDDVGA.ASM` to set the new mode.
- Updates to the memory allocation mask tables in `VDDMEM.ASM` to support the new mode.
- A new `INT 10h` handler in `VDDINT.ASM` to activate the new mode with `AX = 6Fh`.

The implementation assumes a standard SVGA card and that the provided register values are correct for the target hardware.